### PR TITLE
Add 5 Detection Methods

### DIFF
--- a/VMwareCloak.ps1
+++ b/VMwareCloak.ps1
@@ -81,6 +81,36 @@ if ($reg) {
 
    # Remove or rename VMware-related registry keys
 
+    if (Get-ItemProperty -Path "HKLM:\HARDWARE\DEVICEMAP\Scsi\Scsi Port 3\Scsi Bus 1\Target Id 0\Logical Unit Id 0\" -Name "Identifier" -ErrorAction SilentlyContinue) {
+
+        Write-Output "[*] Renaming Reg Key HKLM:\HARDWARE\DEVICEMAP\Scsi\Scsi Port 3\Scsi Bus 1\Target Id 0\Logical Unit Id 0\Identifier"
+        Set-ItemProperty -Path "HKLM:\HARDWARE\DEVICEMAP\Scsi\Scsi Port 3\Scsi Bus 1\Target Id 0\Logical Unit Id 0\" -Name "Identifier" -Value  $(Get-RandomString)
+
+     } Else {
+
+        Write-Output '[!] Reg Key HKLM:\HARDWARE\DEVICEMAP\Scsi\Scsi Port 3\Scsi Bus 1\Target Id 0\Logical Unit Id 0\Identifier" does not seem to exist! Skipping this one...'
+    }
+
+    if (Get-ItemProperty -Path "HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e97d-e325-11ce-bfc1-08002be10318}\0133\" -Name "DriverDesc" -ErrorAction SilentlyContinue) {
+
+        Write-Output "[*] Renaming Reg Key HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e97d-e325-11ce-bfc1-08002be10318}\0133\DriverDesc"
+        Set-ItemProperty -Path "HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e97d-e325-11ce-bfc1-08002be10318}\0133\" -Name "DriverDesc" -Value  $(Get-RandomString)
+
+     } Else {
+
+        Write-Output '[!] Reg Key HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e97d-e325-11ce-bfc1-08002be10318}\0133\DriverDesc does not seem to exist! Skipping this one...'
+    }
+
+    if (Get-ItemProperty -Path "HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e97d-e325-11ce-bfc1-08002be10318}\0133\" -Name "InfSection" -ErrorAction SilentlyContinue) {
+
+        Write-Output "[*] Renaming Reg Key HKLM:SYSTEM\ControlSet001\Control\Class\{4d36e97d-e325-11ce-bfc1-08002be10318}\0133\InfSection"
+        Set-ItemProperty -Path "HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e97d-e325-11ce-bfc1-08002be10318}\0133\" -Name "InfSection" -Value  $(Get-RandomString)
+
+     } Else {
+
+        Write-Output '[!] Reg Key HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e97d-e325-11ce-bfc1-08002be10318}\0133\InfSection does not seem to exist! Skipping this one...'
+    }
+
     if (Get-ItemProperty -Path "HKLM:\HARDWARE\DESCRIPTION\System" -Name "SystemBiosVersion" -ErrorAction SilentlyContinue) {
 
         Write-Output "[*] Renaming Reg Key HKLM:\HARDWARE\DESCRIPTION\System\SystemBiosVersion..."

--- a/VMwareCloak.ps1
+++ b/VMwareCloak.ps1
@@ -103,7 +103,7 @@ if ($reg) {
 
     if (Get-ItemProperty -Path "HKLM:\HARDWARE\DESCRIPTION\System\BIOS" -Name "BIOSVersion" -ErrorAction SilentlyContinue) {
 
-        Write-Output "[*] Renaming Reg Key HKLM:\HARDWARE\DESCRIPTION\System\BIOS\BIOSVendor..."
+        Write-Output "[*] Renaming Reg Key HKLM:\HARDWARE\DESCRIPTION\System\BIOS\BIOSVersion..."
         Set-ItemProperty -Path "HKLM:\HARDWARE\DESCRIPTION\System\BIOS" -Name "BIOSVersion" -Value  1.70
 
      } Else {

--- a/VMwareCloak.ps1
+++ b/VMwareCloak.ps1
@@ -91,6 +91,26 @@ if ($reg) {
         Write-Output '[!] Reg Key HKLM:\HARDWARE\DESCRIPTION\System\SystemBiosVersion does not seem to exist! Skipping this one...'
     }
 
+    if (Get-ItemProperty -Path "HKLM:\HARDWARE\DESCRIPTION\System\BIOS" -Name "BIOSVendor" -ErrorAction SilentlyContinue) {
+
+        Write-Output "[*] Renaming Reg Key HKLM:\HARDWARE\DESCRIPTION\System\BIOS\BIOSVendor..."
+	Set-ItemProperty -Path "HKLM:\HARDWARE\DESCRIPTION\System\BIOS" -Name "BIOSVendor" -Value "American Megatrends International, LLC."
+
+     } Else {
+
+        Write-Output '[!] Reg Key HKLM:\HARDWARE\DESCRIPTION\System\BIOS\BIOSVendor does not seem to exist! Skipping this one...'
+    }
+
+    if (Get-ItemProperty -Path "HKLM:\HARDWARE\DESCRIPTION\System\BIOS" -Name "BIOSVersion" -ErrorAction SilentlyContinue) {
+
+        Write-Output "[*] Renaming Reg Key HKLM:\HARDWARE\DESCRIPTION\System\BIOS\BIOSVendor..."
+        Set-ItemProperty -Path "HKLM:\HARDWARE\DESCRIPTION\System\BIOS" -Name "BIOSVersion" -Value  1.70
+
+     } Else {
+
+        Write-Output '[!] Reg Key HKLM:\HARDWARE\DESCRIPTION\System\BIOS\BIOSVersion does not seem to exist! Skipping this one...'
+    }
+
     if (Get-ItemProperty -Path "HKLM:\HARDWARE\DESCRIPTION\System\BIOS" -Name "SystemManufacturer" -ErrorAction SilentlyContinue) {
 
         Write-Output "[*] Renaming Reg Key HKLM:\HARDWARE\DESCRIPTION\System\BIOS\SystemManufacturer..."


### PR DESCRIPTION
Seems like the script as of now doesn't check these values for whats stored in them, which is important because the values are set to blatant vmware values.

HKEY_LOCAL_MACHINE\HARDWARE\DESCRIPTION\System\BIOS\BIOSVendor
HKEY_LOCAL_MACHINE\HARDWARE\DESCRIPTION\System\BIOS\BIOSVersion

I edited the script to add real data that would be found in a PC in place of the vmware one, I'm not sure if that might conflict with the 'BaseBoard' Values (The manufacturer, product, and version) and since everyone's PC is different.

Hoping you can take a look at this and see if its something that should be changed (and if random values would work in place for that registry key)

top is the VM obviously

![image](https://github.com/user-attachments/assets/6f98c055-e15b-4afd-973d-6de737266840)
